### PR TITLE
Add folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ coverage.xml
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+staticfiles/
 
 # Flask stuff:
 instance/

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,8 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 staticfiles/
+images/
+original_images/
 
 # Flask stuff:
 instance/


### PR DESCRIPTION
Adding the following folders to `.gitignore`:

- `staticfiles/`
- `images/`
- `original_images/`

They are created when using the default conf of the repository (the first is created when running `collectstatic`, the other two when a picture is imported through the dashboard.